### PR TITLE
fix regexp without flags throwing SyntaxError

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ function clone(val, deep) {
 }
 
 function cloneRegExp(val) {
-  const re = new val.constructor(val.source, /\w+$/.exec(val));
+  const flags = /\w+$/.exec(val) || undefined;
+  const re = new val.constructor(val.source, flags);
   re.lastIndex = val.lastIndex;
   return re;
 }

--- a/test.js
+++ b/test.js
@@ -34,9 +34,14 @@ describe('clone()', function() {
       assert.deepEqual(clone([1, 2, 3]), [1, 2, 3]);
     });
 
-    it('should shallow clone a regex', function() {
+    it('should shallow clone a regex with flags', function() {
       assert(clone(/foo/g) !== /foo/g);
       assert.deepEqual(clone(/foo/g), /foo/g);
+    });
+
+    it('should shallow clone a regex without any flags', function() {
+      assert(clone(/foo/) !== /foo/);
+      assert.deepEqual(clone(/foo/), /foo/);
     });
 
     it('should shallow clone a date', function() {


### PR DESCRIPTION
It seems that `RegExp` constructor doesn't like the 2nd param to be `null`, but it can be `undefined`

> SyntaxError: Invalid flags supplied to RegExp constructor 'null'