### PR TITLE
Avoid to use explicit reference to Buffer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ function cloneTypedArray(val, deep) {
 
 function cloneBuffer(val) {
   const len = val.length;
-  const buf = Buffer.allocUnsafe ? Buffer.allocUnsafe(len) : Buffer.from(len);
+  const constructor = val.constructor;
+  const buf = constructor.allocUnsafe ? constructor.allocUnsafe(len) : constructor.from(len);
   val.copy(buf);
   return buf;
 }


### PR DESCRIPTION
That allows to use in web bundlers (like webpack) without include the Buffer polyfill or need to explicitly exclude it.

It uses the same strategy used for other types, like typed arrays.