### PR TITLE
Bump kind-of to `^6.0.3` for fixing vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "kind-of": "^6.0.2"
+    "kind-of": "^6.0.3"
   },
   "devDependencies": {
     "gulp-format-md": "^2.0.0",


### PR DESCRIPTION
The semver range already includes `6.0.3`, but it doesn't disallow lower versions. So for the best security, it should be upgraded in `package.json`.